### PR TITLE
 FCBHDBP-595 biblebrain prep work

### DIFF
--- a/core/adapters/mysql/repository/bible_file_timestamps.go
+++ b/core/adapters/mysql/repository/bible_file_timestamps.go
@@ -21,21 +21,31 @@ func NewBibleFileWithGapsRepository(db *gorm.DB) repository.BibleFileWithGapsRep
 // This method creates a temporary table called bible_files_with_timestamp_gaps which holds information about
 // Bible files with gaps in their timestamp sequences.
 func (r BibleFileWithGapsRepository) CreateTempTable() error {
-	sql := `CREATE TEMPORARY TABLE bible_files_with_timestamp_gaps SELECT bfc.bible_id,
-		bf2.id as bible_file_id,
-		bf2.book_id,
-		bf2.chapter_start,
-		bf2.file_name as bible_file_name,
-		SUM(bft.verse_sequence) AS sum_verses,
-		COUNT(bft.verse_sequence) AS count_verses,
-		(COUNT(bft.verse_sequence)*(COUNT(bft.verse_sequence)+1))/2 AS formula_sum_of_n
-		FROM bible_fileset_connections bfc 
-		JOIN bible_filesets bf ON bfc.hash_id = bf.hash_id
-		JOIN bible_files bf2 ON bf2.hash_id = bf.hash_id 
-		JOIN bible_file_timestamps bft ON bft.bible_file_id = bf2.id
-		WHERE bft.verse_sequence <> 0
-		GROUP BY bfc.bible_id, bf2.id, bf2.book_id, bf2.file_name,bf2.chapter_start
-		HAVING SUM(bft.verse_sequence) <> (COUNT(bft.verse_sequence)*(COUNT(bft.verse_sequence)+1))/2;`
+	sql := `CREATE TEMPORARY TABLE bible_files_with_timestamp_gaps SELECT sub.*
+	FROM (
+			SELECT bfc.bible_id,
+				bf2.id as bible_file_id,
+				bf2.book_id,
+				bf2.chapter_start,
+				bf2.file_name as bible_file_name,
+				SUM(CASE
+					WHEN bft.verse_end IS NULL THEN bft.verse_sequence
+					WHEN bft.verse_end > 0 and bft.verse_end > bft.verse_sequence THEN (bft.verse_end*(bft.verse_end+1))/2 - (bft.verse_sequence*(bft.verse_sequence-1))/2
+					ELSE bft.verse_sequence
+				END) AS sum_verses,
+				SUM(CASE
+					WHEN bft.verse_end IS NULL THEN 1
+					WHEN bft.verse_end > 0 and bft.verse_end > bft.verse_sequence THEN (bft.verse_end - bft.verse_sequence) + 1
+					ELSE 1
+				END) AS count_verses
+			FROM bible_fileset_connections bfc
+			JOIN bible_filesets bf ON bfc.hash_id = bf.hash_id
+			JOIN bible_files bf2 ON bf2.hash_id = bf.hash_id
+			JOIN bible_file_timestamps bft ON bft.bible_file_id = bf2.id
+			WHERE bft.verse_sequence <> 0
+			GROUP BY bfc.bible_id, bf2.id, bf2.book_id, bf2.file_name, bf2.chapter_start
+		) AS sub
+	WHERE sub.sum_verses <> (sub.count_verses*(sub.count_verses+1))/2;`
 
 	return r.db.Exec(sql).Error
 }


### PR DESCRIPTION
# Description
fix the `bible_files_with_timestamp_gaps` query to avoid retrieving records that have already been fixed.

## NOTE 1
It is related to bible-uploader PR:
- https://github.com/faithcomesbyhearing/biblebrain-uploader/pull/2

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-595

## How Do I QA This
We need to import the biblebrain-common module into the biblebrain-uploader project and you should run the following command and it works correctly.

```bash
./bin/biblebrain-uploader fix-timestamp-gap -l 3
```

```bash
# biblebrain-uploader is a command tool to:

Update records in the bible_file_timestamps entity using a specific SQL query

Usage:
  biblebrain-uploader fix-timestamp-gap [flags]

Flags:
  -h, --help        help for fix-timestamp-gap
  -l, --limit int   Limit of records to retrieve (default 10)
```